### PR TITLE
Various additions

### DIFF
--- a/src/enums/DiscordChannelTypes.js
+++ b/src/enums/DiscordChannelTypes.js
@@ -1,19 +1,8 @@
-/**
- * The discord channel types.
- * @enum {number}
- * @readonly
- */
-
 const DiscordChannelTypes = {
-  /** A guild text channel. */
   TextChannel: 0,
-  /** A DM channel. */
   DM: 1,
-  /** A guild voice channel. */
   VoiceChannel: 2,
-  /** A group channel. */
   GroupChannel: 3,
-  /** A guild category. */
   GuildCategory: 4
 };
 

--- a/src/enums/PatronOptions.js
+++ b/src/enums/PatronOptions.js
@@ -1,0 +1,14 @@
+/**
+ * The options for Patron.
+ * @enum {Symbol}
+ * @readonly
+ */
+
+const PatronOptions = {
+  /** The eris library */
+  ErisLibrary: Symbol(),
+  /** The discord.js library */
+  DiscordJSLibrary: Symbol()
+};
+
+module.exports = PatronOptions;

--- a/src/enums/TypeReaderCategories.js
+++ b/src/enums/TypeReaderCategories.js
@@ -1,0 +1,16 @@
+/**
+ * The type reader categories.
+ * @enum {number}
+ * @readonly
+ */
+
+const TypeReaderCategories = {
+  /** Global type readers. */
+  Global: Symbol(),
+  /** Library-specific type readers. */
+  Library: Symbol(),
+  /** User-made type readers. */
+  User: Symbol()
+};
+
+module.exports = TypeReaderCategories;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ module.exports = {
   Result: require('./results/Result.js'),
   RequireAll: require('./utility/RequireAll.js'),
   TypeReader: require('./structures/TypeReader.js'),
+  TypeReaderCategories: require('./enums/TypeReaderCategories.js'),
   TypeReaderResult: require('./results/TypeReaderResult.js'),
   version: require('../package.json').version
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,13 @@ module.exports = {
   ExceptionResult: require('./results/ExceptionResult.js'),
   Group: require('./structures/Group.js'),
   Handler: require('./structures/Handler.js'),
+  Options: require('./enums/PatronOptions.js'),
   Precondition: require('./structures/Precondition.js'),
   PreconditionResult: require('./results/PreconditionResult.js'),
   Registry: require('./structures/Registry.js'),
   Result: require('./results/Result.js'),
   RequireAll: require('./utility/RequireAll.js'),
   TypeReader: require('./structures/TypeReader.js'),
-  TypeReaderCategories: require('./enums/TypeReaderCategories.js'),
   TypeReaderResult: require('./results/TypeReaderResult.js'),
   version: require('../package.json').version
 };

--- a/src/readers/discord.js/BannedUserTypeReader.js
+++ b/src/readers/discord.js/BannedUserTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class BannedUserTypeReader extends TypeReader {
   constructor() {
     super({ type: 'banneduser' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/CategoryChannelTypeReader.js
+++ b/src/readers/discord.js/CategoryChannelTypeReader.js
@@ -3,9 +3,9 @@ const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
-class ChannelTypeReader extends TypeReader {
+class CategoryChannelTypeReader extends TypeReader {
   constructor() {
-    super({ type: 'channel' });
+    super({ type: 'categorychannel' });
 
     this.category = TypeReaderCategories.Library;
   }
@@ -14,13 +14,13 @@ class ChannelTypeReader extends TypeReader {
     if (Constants.regexes.id.test(input) === true) {
       const channel = message.client.channels.get(input.match(Constants.regexes.findId)[0]);
 
-      if (channel !== undefined) {
+      if (channel !== undefined && channel.type === 'category') {
         return TypeReaderResult.fromSuccess(channel);
       }
     }
 
-    return TypeReaderResult.fromError(command, Constants.errors.channelNotFound);
+    return TypeReaderResult.fromError(command, Constants.errors.dmChannelNotFound);
   }
 }
 
-module.exports = new ChannelTypeReader();
+module.exports = new CategoryChannelTypeReader();

--- a/src/readers/discord.js/DMChannelTypeReader.js
+++ b/src/readers/discord.js/DMChannelTypeReader.js
@@ -1,10 +1,13 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
 class DMChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'dmchannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/EmojiTypeReader.js
+++ b/src/readers/discord.js/EmojiTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class EmojiTypeReader extends TypeReader {
   constructor() {
     super({ type: 'emoji' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/GroupChannelTypeReader.js
+++ b/src/readers/discord.js/GroupChannelTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class GroupChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'groupchannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/GuildChannelTypeReader.js
+++ b/src/readers/discord.js/GuildChannelTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class GuildChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'guildchannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/GuildEmojiTypeReader.js
+++ b/src/readers/discord.js/GuildEmojiTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class GuildEmojiTypeReader extends TypeReader {
   constructor() {
     super({ type: 'guildemoji' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/GuildTypeReader.js
+++ b/src/readers/discord.js/GuildTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class GuildTypeReader extends TypeReader {
   constructor() {
     super({ type: 'guild' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/MemberTypeReader.js
+++ b/src/readers/discord.js/MemberTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class MemberTypeReader extends TypeReader {
   constructor() {
     super({ type: 'member' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/MessageTypeReader.js
+++ b/src/readers/discord.js/MessageTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class MessageTypeReader extends TypeReader {
   constructor() {
     super({ type: 'message' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/RoleTypeReader.js
+++ b/src/readers/discord.js/RoleTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class RoleTypeReader extends TypeReader {
   constructor() {
     super({ type: 'role' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/TextChannelTypeReader.js
+++ b/src/readers/discord.js/TextChannelTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class TextChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'textchannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/UserTypeReader.js
+++ b/src/readers/discord.js/UserTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class UserTypeReader extends TypeReader {
   constructor() {
     super({ type: 'user' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/discord.js/VoiceChannelTypeReader.js
+++ b/src/readers/discord.js/VoiceChannelTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class VoiceChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'voicechannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/BannedUserTypeReader.js
+++ b/src/readers/eris/BannedUserTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class BannedUserTypeReader extends TypeReader {
   constructor() {
     super({ type: 'banneduser' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/CategoryChannelTypeReader.js
+++ b/src/readers/eris/CategoryChannelTypeReader.js
@@ -15,7 +15,7 @@ class CategoryChannelTypeReader extends TypeReader {
     if (Constants.regexes.id.test(input) === true) {
       const channel = message._client.channels.find((c) => c.id === input.match(Constants.regexes.findId)[0]);
 
-      if (channel !== undefined && channel.type === DiscordChannelTypes.GuildCategory) {
+      if (channel !== undefined && channel.type === DiscordChannelTypes.Category) {
         return TypeReaderResult.fromSuccess(channel);
       }
     }

--- a/src/readers/eris/CategoryChannelTypeReader.js
+++ b/src/readers/eris/CategoryChannelTypeReader.js
@@ -1,26 +1,27 @@
+const DiscordChannelTypes = require('../../enums/DiscordChannelTypes.js');
 const TypeReader = require('../../structures/TypeReader.js');
 const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
-class ChannelTypeReader extends TypeReader {
+class CategoryChannelTypeReader extends TypeReader {
   constructor() {
-    super({ type: 'channel' });
+    super({ type: 'categorychannel' });
 
     this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {
     if (Constants.regexes.id.test(input) === true) {
-      const channel = message.client.channels.get(input.match(Constants.regexes.findId)[0]);
+      const channel = message._client.channels.find((c) => c.id === input.match(Constants.regexes.findId)[0]);
 
-      if (channel !== undefined) {
+      if (channel !== undefined && channel.type === DiscordChannelTypes.GuildCategory) {
         return TypeReaderResult.fromSuccess(channel);
       }
     }
 
-    return TypeReaderResult.fromError(command, Constants.errors.channelNotFound);
+    return TypeReaderResult.fromError(command, Constants.errors.dmChannelNotFound);
   }
 }
 
-module.exports = new ChannelTypeReader();
+module.exports = new CategoryChannelTypeReader();

--- a/src/readers/eris/ChannelTypeReader.js
+++ b/src/readers/eris/ChannelTypeReader.js
@@ -1,10 +1,13 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
 class ChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'channel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/DMChannelTypeReader.js
+++ b/src/readers/eris/DMChannelTypeReader.js
@@ -1,11 +1,14 @@
 const DiscordChannelTypes = require('../../enums/DiscordChannelTypes.js');
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
 class DMChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'dmchannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/EmojiTypeReader.js
+++ b/src/readers/eris/EmojiTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class EmojiTypeReader extends TypeReader {
   constructor() {
     super({ type: 'emoji' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/GroupChannelTypeReader.js
+++ b/src/readers/eris/GroupChannelTypeReader.js
@@ -1,5 +1,6 @@
 const DiscordChannelTypes = require('../../enums/DiscordChannelTypes.js');
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -7,6 +8,8 @@ const Constants = require('../../utility/Constants.js');
 class GroupChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'groupchannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/GuildChannelTypeReader.js
+++ b/src/readers/eris/GuildChannelTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class GuildChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'guildchannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/GuildEmojiTypeReader.js
+++ b/src/readers/eris/GuildEmojiTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class GuildEmojiTypeReader extends TypeReader {
   constructor() {
     super({ type: 'guildemoji' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/GuildTypeReader.js
+++ b/src/readers/eris/GuildTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class GuildTypeReader extends TypeReader {
   constructor() {
     super({ type: 'guild' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/MemberTypeReader.js
+++ b/src/readers/eris/MemberTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -7,6 +8,8 @@ let warningEmitted = false;
 class MemberTypeReader extends TypeReader {
   constructor() {
     super({ type: 'member' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/MessageTypeReader.js
+++ b/src/readers/eris/MessageTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class MessageTypeReader extends TypeReader {
   constructor() {
     super({ type: 'message' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/RoleTypeReader.js
+++ b/src/readers/eris/RoleTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -6,6 +7,8 @@ const Constants = require('../../utility/Constants.js');
 class RoleTypeReader extends TypeReader {
   constructor() {
     super({ type: 'role' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/TextChannelTypeReader.js
+++ b/src/readers/eris/TextChannelTypeReader.js
@@ -1,5 +1,6 @@
 const DiscordChannelTypes = require('../../enums/DiscordChannelTypes.js');
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -7,6 +8,8 @@ const Constants = require('../../utility/Constants.js');
 class TextChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'textchannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/UserTypeReader.js
+++ b/src/readers/eris/UserTypeReader.js
@@ -1,4 +1,5 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -7,6 +8,8 @@ let warningEmitted = false;
 class UserTypeReader extends TypeReader {
   constructor() {
     super({ type: 'user' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/eris/VoiceChannelTypeReader.js
+++ b/src/readers/eris/VoiceChannelTypeReader.js
@@ -1,5 +1,6 @@
 const DiscordChannelTypes = require('../../enums/DiscordChannelTypes.js');
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const TypeReaderUtil = require('../../utility/TypeReaderUtil.js');
 const Constants = require('../../utility/Constants.js');
@@ -7,6 +8,8 @@ const Constants = require('../../utility/Constants.js');
 class VoiceChannelTypeReader extends TypeReader {
   constructor() {
     super({ type: 'voicechannel' });
+
+    this.category = TypeReaderCategories.Library;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/global/BooleanTypeReader.js
+++ b/src/readers/global/BooleanTypeReader.js
@@ -1,10 +1,13 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
 class BooleanTypeReader extends TypeReader {
   constructor() {
     super({ type: 'bool' });
+
+    this.category = TypeReaderCategories.Global;
   }
 
   async read(command, message, argument, args, value) {

--- a/src/readers/global/FloatTypeReader.js
+++ b/src/readers/global/FloatTypeReader.js
@@ -1,10 +1,13 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
 class FloatTypeReader extends TypeReader {
   constructor() {
     super({ type: 'float' });
+
+    this.category = TypeReaderCategories.Global;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/global/IntTypeReader.js
+++ b/src/readers/global/IntTypeReader.js
@@ -1,10 +1,13 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
 class IntTypeReader extends TypeReader {
   constructor() {
     super({ type: 'int' });
+
+    this.category = TypeReaderCategories.Global;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/global/QuantityTypeReader.js
+++ b/src/readers/global/QuantityTypeReader.js
@@ -1,10 +1,13 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
 class QuantityTypeReader extends TypeReader {
   constructor() {
     super({ type: 'quantity' });
+
+    this.category = TypeReaderCategories.Global;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/global/StringTypeReader.js
+++ b/src/readers/global/StringTypeReader.js
@@ -1,9 +1,12 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 
 class StringTypeReader extends TypeReader {
   constructor() {
     super({ type: 'string' });
+
+    this.category = TypeReaderCategories.Global;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/readers/global/TimeTypeReader.js
+++ b/src/readers/global/TimeTypeReader.js
@@ -1,10 +1,13 @@
 const TypeReader = require('../../structures/TypeReader.js');
+const TypeReaderCategories = require('../../enums/TypeReaderCategories.js');
 const TypeReaderResult = require('../../results/TypeReaderResult.js');
 const Constants = require('../../utility/Constants.js');
 
 class TimeTypeReader extends TypeReader {
   constructor() {
     super({ type: 'time' });
+
+    this.category = TypeReaderCategories.Global;
   }
 
   async read(command, message, argument, args, input) {

--- a/src/structures/Handler.js
+++ b/src/structures/Handler.js
@@ -24,7 +24,7 @@ class Handler {
    */
   async run(message, prefix, ...custom) {
     try {
-      const split = message.content.slice(prefix.length).match(Constants.regexes.argument);
+      const split = message.content.slice(prefix.length).match(this.registry.argumentRegex);
 
       if (split === null) {
         return Constants.results.commandNotFound('');

--- a/src/structures/TypeReader.js
+++ b/src/structures/TypeReader.js
@@ -1,6 +1,9 @@
+const TypeReaderCategories = require('../enums/TypeReaderCategories.js');
+
 /**
  * A type reader.
  * @prop {string} type The type of the type reader.
+ * @prop {string} category Which category the type reader belongs to.
  * @prop {string} description The description of the type reader.
  */
 class TypeReader {
@@ -14,6 +17,7 @@ class TypeReader {
     * @param {TypeReaderOptions} options The type reader options.
     */
   constructor(options) {
+    this.category = TypeReaderCategories.User;
     this.type = options.type;
     this.description = options.description !== undefined ? options.description : '';
 

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -1,6 +1,7 @@
 const Result = require('../results/Result.js');
 const PermissionUtil = require('../utility/PermissionUtil.js');
 const CommandError = require('../enums/CommandError.js');
+const PatronOptions = require('../enums/PatronOptions.js');
 
 class Constants {
   constructor() {
@@ -104,8 +105,8 @@ class Constants {
     ];
 
     this.libraries = [
-      'discord.js',
-      'eris'
+      PatronOptions.DiscordJSLibrary,
+      PatronOptions.ErisLibrary
     ];
   }
 }


### PR DESCRIPTION
**Additions:**
 * `enums/PatronOptions.js` - All string-like input options for patron.js
 * `enums/TypeReaderCategories.js` - All of the `TypeReader` categories (see `TypeReader.category`)
 * `readers/CategoryChannelTypeReader.js` - `TypeReader` for type 4 channels (category channels)
 * `Registry.unregisterArgumentPreconditions(Array.<ArgumentPrecondition>);` - Unregisters `ArgumentPrecondition`s
 * `Registry.unregisterCommands(Array.<Command>);` - Unregisters `Command`s
 * `Registry.unregisterGroups(Array.<Group>);` - Unregisters `Group`s
 * `Registry.unregisterPreconditions(Array.<Precondition>);` - Unregisters `Precondition`s
 * `Registry.unregisterTypeReaders(Array.<TypeReader>);` - Unregisters `TypeReader`s
   * `Registry.unregisterGlobalTypeReaders();` - Unregisters `TypeReader`s in the `Global` category
   * `Registry.unregisterLibraryTypeReaders();` - Unregisters `TypeReader`s in the `Library` category
 * `TypeReader.category` - Makes programmatically determining where a `TypeReader` came from possible

**Changes:**
 * `enums/DiscordChannelTypes.js` - Removed from documentation due to a lack of usability or usefulness
 * `index.js` - Added `PatronOptions.js` as `module.exports.Options` to allow for usage of the new input option constants