### PR TITLE
Add Repeatable

### DIFF
--- a/src/structures/Argument.js
+++ b/src/structures/Argument.js
@@ -23,6 +23,10 @@ const Constants = require("../utility/Constants.js");
  * @prop {string} example The argument's example.
  * @prop {boolean} infinite Allow the argument to accept an infinite number of
  * values and return them in an array.
+ * @prop {boolean} repeatable Repeate argument until it returns an error. If the
+ * first arugment returns error, it will fail.
+ * @prop {number} maxRepeats Stops repeatable arguments if they repeat more than this.
+ * -1 is infinite.
  * @prop {string} key The argument's property name on the args object.
  * @prop {string} name The argument's name.
  * @prop {boolean} optional Whether or not the argument is optional.
@@ -40,6 +44,10 @@ class Argument {
    * @prop {string} example The argument's example.
    * @prop {boolean} [infinite=false] Allow this argument accept an infinite
    * number of values and return them in an array.
+   * @prop {boolean} [repeatable=false] Repeate argument until it returns an error. If the
+   * first arugment returns error, it will fail.
+   * @prop {number} [maxRepeats=-1] Stops repeatable arguments if they repeat more than this.
+   * -1 is infinite.
    * @prop {string} key The argument's property name on the args object.
    * @prop {string} name The argument's name.
    * @prop {Array<*>} [preconditionOptions=[]] The options to be passed to
@@ -59,6 +67,8 @@ class Argument {
     this.defaultValue = options.defaultValue;
     this.example = options.example;
     this.infinite = options.infinite == null ? false : options.infinite;
+    this.repeatable = options.repeatable == null ? false : options.repeatable;
+    this.maxRepeats = options.maxRepeats == null ? -1 : options.maxRepeats;
     this.key = options.key;
     this.name = options.name;
 
@@ -86,7 +96,15 @@ class Argument {
       throw new TypeError(
         `${argument.constructor.name}: The infinite setting must be a boolean.`
       );
-    } else if (typeof argument.key !== "string"
+    } else if (typeof argument.repeatable !== "boolean") {
+      throw new TypeError(
+        `${argument.constructor.name}: The repeatable setting must be a boolean.`
+      );
+    } else if (typeof argument.maxRepeats !== "number") {
+      throw new TypeError(
+        `${argument.constructor.name}: The repeatable setting must be a number.`
+      );
+    }  else if (typeof argument.key !== "string"
         || Constants.regexes.whiteSpace.test(argument.key)) {
       throw new TypeError(
         `${argument.constructor.name}: The key must be a string that does not \

--- a/src/structures/Argument.js
+++ b/src/structures/Argument.js
@@ -102,7 +102,7 @@ class Argument {
       );
     } else if (typeof argument.maxRepeats !== "number") {
       throw new TypeError(
-        `${argument.constructor.name}: The repeatable setting must be a number.`
+        `${argument.constructor.name}: The maxRepeats setting must be a number.`
       );
     }  else if (typeof argument.key !== "string"
         || Constants.regexes.whiteSpace.test(argument.key)) {

--- a/src/structures/Handler.js
+++ b/src/structures/Handler.js
@@ -330,6 +330,34 @@ class Handler {
 
           val = res;
         }
+      } else if (cmd.args[i].repeatable) {
+        let values = [];
+        let s;
+        for (let repeats = 0; cmd.args[i].maxRepeats === -1 || repeats < cmd.args[i].maxRepeats; repeats++) {
+          s = split[0];
+          let res = await this.parseFiniteArg(msg, cmd, i, args, cnt, split);
+
+          let val = res.result.value;
+          cnt = res.content;
+
+          if (res.result.success === false && repeats === 0)
+            return res.result;
+          else if (res.result.success === false && repeats > 0) {
+            split.unshift(s);
+            break;
+          }
+
+          res = await this.runArgPreconditions(msg, cmd, i, args, val);
+
+          if (res != null && repeats === 0)
+            return res;
+          else if (res != null && repeats > 0) {
+            split.unshift(s);
+            break;
+          } else
+            values.push(val);
+        }
+        val = values;
       } else {
         let res = await this.parseFiniteArg(msg, cmd, i, args, cnt, split);
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -105,6 +105,8 @@ declare module "patron.js" {
     public defaultValue: any;
     public example: string;
     public infinite: boolean;
+    public repeatable: boolean;
+    public maxRepeats: number;
     public key: string;
     public name: string;
     public optional: boolean;
@@ -281,6 +283,8 @@ declare module "patron.js" {
     defaultValue?: any;
     example: string;
     infinite?: boolean;
+    repeatable?: boolean;
+    maxRepeats?: number;
     key: string;
     name: string;
     preconditionOptions?: any[];


### PR DESCRIPTION
The repeatable option repeats an argument until it runs into an error and moves onto the next argument. If the argument fails on first time, it will also fail.

Test/Example
Type reader
```typescript
import { TypeReader, TypeReaderResult, Command, Argument } from "patron.js"

export = new class Mentions extends TypeReader {
    constructor() {
        super({
            type: 'mentions'
        });
    }

    async read(command: Command, message: any, argument: Argument, args: any, input: String) {
        const match = input.match(/<@!?(\d{14,20})>/);

        if (match && match[1]) {
            return TypeReaderResult.fromSuccess(match[1]);
        }
        return TypeReaderResult.fromError(command, 'Not a mention');
    }
}
```
Command
```typescript
import { Command, Argument } from "patron.js";
import { Message } from "eris";
import client from '../client';

export = new class Test extends Command {
    constructor() {
        super({
            groupName: "util",
            names: ["test"],
            memberPermissions: ["sendMessages"],
            args: [
                new Argument({ name: 'test', key: 'test', example: 'test', type: 'mentions', repeatable: true }),
                new Argument({ name: 'test2', key: 'test2', example: 'test2', type: 'string' })
            ]
        });
    }

    async run(msg: Message, args: any) {
        await client.createMessage(msg.channel.id, JSON.stringify(args, null, 2));
    }
}
```